### PR TITLE
Fix documentation of expected input format

### DIFF
--- a/chi2FitXYErr.py
+++ b/chi2FitXYErr.py
@@ -41,7 +41,7 @@ BESCHREIBUNG:
   als auch in den y-Koordinaten, mit Fehlern behaftet sind.
   
   Programm Eingabe ist eine Datei (Programmoption -i) mit vier Spalten:
-  x y fehler_x fehler_y
+  x fehler_x y fehler_y
   
   Die Datei darf Kommentarzeilen, die mit einem '#' eingeleitet werden,
   enthalten,


### PR DESCRIPTION
The script expects its input to consist of columns x, error_x, y,
error_y, in that order, as can be seen on lines 93 to 96.

This order matches the one of the files provided in experiment 114.